### PR TITLE
syms is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var engine = require('./lib/wrap').engine;
+let syms;
 if (!engine) {
 	syms = require("./lib/pure");
 } else {


### PR DESCRIPTION
I'm packing up keybase using webpack, and when running, I get an error that syms is not defined.

The answer is to define syms :-)